### PR TITLE
Add https to the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ var Sample2 = React.createClass({
         ref="webviewbridge"
         onBridgeMessage={this.onBridgeMessage.bind(this)}
         injectedJavaScript={injectScript}
-        source={{uri: "http://google.com"}}/>
+        source={{uri: "https://google.com"}}/>
     );
   }
 });


### PR DESCRIPTION
Hi there, 

While trying out the README example I got this little error, so I though I will add the s in there for others that might run into the same issue

![captura de pantalla 2016-11-13 a las 23 50 06](https://cloud.githubusercontent.com/assets/3205919/20249914/f0a642b6-a9fb-11e6-89dd-10560c737679.png)

Great package, cheers